### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/github_a_branch_protection_requirement_was_overridden_by_a_repository_administrator.yml
+++ b/rules/github_a_branch_protection_requirement_was_overridden_by_a_repository_administrator.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate your organization's incident response process and investigate.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_audit_log_streaming_endpoint_was_deleted.yml
+++ b/rules/github_audit_log_streaming_endpoint_was_deleted.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and Response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate your organization's incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_audit_log_streaming_endpoint_was_modified.yml
+++ b/rules/github_audit_log_streaming_endpoint_was_modified.yml
@@ -13,7 +13,6 @@ description: |-
 
   1. Determine if the change made by the actor is authorized.
   2. If the change was not authorized or was unexpected, initiate the organization's incident response process and conduct an investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_branch_protection_disabled_on_branch.yml
+++ b/rules/github_branch_protection_disabled_on_branch.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the organization's incident response process and investigate.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_enterprise_owner_added.yml
+++ b/rules/github_enterprise_owner_added.yml
@@ -19,7 +19,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the organization's incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_mfa_requirement_disabled.yml
+++ b/rules/github_mfa_requirement_disabled.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and Response
   1. Determine if the change made by the actor is authorized.
   2. If the change is unauthorized or unexpected, initiate your organization's incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_oauth_application_access_restrictions_disabled.yml
+++ b/rules/github_oauth_application_access_restrictions_disabled.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and Response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the organization's incident response process and investigate.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_organization_was_removed_from_enterprise.yml
+++ b/rules/github_organization_was_removed_from_enterprise.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_organization_was_transferred_between_enterprise_accounts.yml
+++ b/rules/github_organization_was_transferred_between_enterprise_accounts.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Verify if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_payment_method_removed.yml
+++ b/rules/github_payment_method_removed.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change taken by the actor is authorized.
   2. If the change was not authorized or unexpected, begin your organization's incident response process and investigate.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_personal_access_token_pat_auto_approve_policy_modified.yml
+++ b/rules/github_personal_access_token_pat_auto_approve_policy_modified.yml
@@ -13,7 +13,6 @@ description: |-
 
   1. Determine if the change made by the actor is authorized.
   2. If the change was not authorized or unexpected, initiate your organization's incident response process and investigate.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_private_repository_changed_to_public_visibility.yml
+++ b/rules/github_private_repository_changed_to_public_visibility.yml
@@ -13,7 +13,6 @@ description: |-
 
   1. Verify if the change made by the actor is authorized.
   2. If the change is unauthorized or unexpected, initiate your organization's incident response process and conduct an investigation.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_saml_oidc_has_been_disabled.yml
+++ b/rules/github_saml_oidc_has_been_disabled.yml
@@ -13,7 +13,6 @@ description: |-
 
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the organization's incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_secret_scanning_alert_generated.yml
+++ b/rules/github_secret_scanning_alert_generated.yml
@@ -15,7 +15,6 @@ description: |-
 
   1. Assess whether the detected secret is sensitive for your environment.
   2. If the secret's publication poses a risk, initiate your incident response process and investigate.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_ssh_certificate_authority_deleted.yml
+++ b/rules/github_ssh_certificate_authority_deleted.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the GitHub actor is authorized.
   2. If the change was not authorized or was unexpected, initiate your organization's incident response process and investigate.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_ssh_certificate_requirement_disabled.yml
+++ b/rules/github_ssh_certificate_requirement_disabled.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate the organization's incident response process and conduct an investigation.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_unknown_user_cloned_private_repository.yml
+++ b/rules/github_unknown_user_cloned_private_repository.yml
@@ -13,7 +13,6 @@ description: |-
 
   1. Check if the IP address associated with the clone action belongs to a known corporate device.
   2. If the action cannot be traced back to an internal user, initiate your organization's incident response process and conduct an investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:github

--- a/rules/github_user_blocked_from_accessing_organization_repositories.yml
+++ b/rules/github_user_blocked_from_accessing_organization_repositories.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the change made by the actor is authorized.
   2. If the change was unauthorized or unexpected, initiate your organization's incident response process and investigate.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:github


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.